### PR TITLE
Fix typo of Description key in plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "ID": "435b5226a00840cebfbdb54dacd26e9d",
-  "Decription": "Opens workspaces, remote machines (SSH or Codespaces) and containers, previously opened in Cursor.",
+  "Description": "Opens workspaces, remote machines (SSH or Codespaces) and containers, previously opened in Cursor.",
   "ActionKeyword": "cu",
   "Name": "Cursor Workspaces",
   "Author": "cou723",


### PR DESCRIPTION
In your plugin.json, `Description` is misspelled